### PR TITLE
#29 corporations

### DIFF
--- a/client/static/script/app.js
+++ b/client/static/script/app.js
@@ -44,7 +44,7 @@ var app = {
   env: {},
   tick: 0,
   newAction: false,
-  keys: ["a", "w", "s", "d", "k", "l", "m"],
+  keys: ["a", "w", "s", "d", "k", "l", "m", "i", "-", "+"],
   actions: [],
   lastAction: "a",
   lastHealth: 100,

--- a/client/static/script/view.js
+++ b/client/static/script/view.js
@@ -4,7 +4,7 @@
 //called by app.js after id is populated, etc
 var contentId = "content";
 var pollDelay = 350;
-var validKeys = {"w":true,"a":true,"s":true,"d":true,"m":true,"k":true,"l":true};
+var validKeys = {"w":true,"a":true,"s":true,"d":true,"m":true,"k":true,"l":true,"i":true,"-":true,"+":true};
 var view = {
   contentDiv: null,
   SetupView : function(callback) {

--- a/server/cell.py
+++ b/server/cell.py
@@ -66,8 +66,11 @@ class Cell:
                 if self.contains_object_type(i)[0]:
                     for obj in self.contents:
                         if obj.__class__.__name__ == i:
-                            if obj.obj_id == player_id:
-                                return obj.inner_icon
+                            if obj.__class__.__name__ == 'Player':
+                                if obj.obj_id == player_id:
+                                    return obj.inner_icon
+                                else:
+                                    return obj.neutral_icon
                             else:
                                 return obj.icon
             return '.'  # Returns Empty Space

--- a/server/cell.py
+++ b/server/cell.py
@@ -69,6 +69,8 @@ class Cell:
                             if obj.__class__.__name__ == 'Player':
                                 if obj.obj_id == player_id:
                                     return obj.inner_icon
+                                elif obj.corp.check_if_in_corp(player_id):
+                                    return obj.corp_member_icon
                                 else:
                                     return obj.neutral_icon
                             else:

--- a/server/corporation.py
+++ b/server/corporation.py
@@ -39,7 +39,18 @@ class Corporation:
 
     def receive_merge_invite(self, corp_id):
         self.received_merge_invites.append(corp_id)
+        self.check_if_corp_can_merge_and_if_so_merge()
 
     def send_merge_invite(self, corp_id):
         self.sent_merge_invites.append(corp_id)
         self.world.corporations[corp_id].receive_merge_invite(self.corp_id)
+
+    def check_if_corp_can_merge_and_if_so_merge(self):
+        for received in self.received_merge_invites:
+            if received in self.sent_merge_invites:
+                corp_id_to_merge_with = received
+                self.world.corporations[corp_id_to_merge_with].merge_me(self.corp_id)
+
+    def merge_me(self, other_corp_id):  # Another corp will call this with their corp id to indicate that they want to be merged into our corp
+        for member in self.world.corporations[other_corp_id].members:
+            member.corp = self  # Setting the other corp's members corp to our corp

--- a/server/corporation.py
+++ b/server/corporation.py
@@ -42,8 +42,9 @@ class Corporation:
         self.check_if_corp_can_merge_and_if_so_merge()
 
     def send_merge_invite(self, corp_id):
-        self.sent_merge_invites.append(corp_id)
-        self.world.corporations[corp_id].receive_merge_invite(self.corp_id)
+        if self.corp_id != corp_id:
+            self.sent_merge_invites.append(corp_id)
+            self.world.corporations[corp_id].receive_merge_invite(self.corp_id)
 
     def check_if_corp_can_merge_and_if_so_merge(self):
         for received in self.received_merge_invites:
@@ -52,5 +53,9 @@ class Corporation:
                 self.world.corporations[corp_id_to_merge_with].merge_me(self.corp_id)
 
     def merge_me(self, other_corp_id):  # Another corp will call this with their corp id to indicate that they want to be merged into our corp
+        self.sent_merge_invites = list([])  # Empties the sent merge invites list
+        self.received_merge_invites = list([])  # Empties the received merge invites list
+
+        self.gain_ore(self.world.corporations[other_corp_id].ore_quantity)  # Incorporates their ore bank into our ore bank
         for member in self.world.corporations[other_corp_id].members:
             member.corp = self  # Setting the other corp's members corp to our corp

--- a/server/corporation.py
+++ b/server/corporation.py
@@ -16,5 +16,14 @@ class Corporation:
         assert(member.__class__.__name__ == 'Player')
         self.members.append(member)
 
-    def calculate_ore_lost_on_death(self):
+    def gain_ore(self, amount):
+        self.ore_quantity += amount
+
+    def lose_ore(self, amount):
+        self.ore_quantity -= amount
+
+    def amount_of_ore(self):
+        return self.ore_quantity
+
+    def calculate_ore_loss_on_death(self):
         return int(self.ore_quantity / len(self.members))

--- a/server/corporation.py
+++ b/server/corporation.py
@@ -1,0 +1,20 @@
+import gameObject, uuid
+
+
+class Corporation:
+
+    def __init__(self, initial_member):
+        assert(initial_member.__class__.__name__ == 'Player')
+
+        self.corp_id = str(uuid.uuid4())
+        self.members = []
+        self.ore_quantity = 0
+
+        self.add_member(initial_member)
+
+    def add_member(self, member):
+        assert(member.__class__.__name__ == 'Player')
+        self.members.append(member)
+
+    def calculate_ore_lost_on_death(self):
+        return int(self.ore_quantity / len(self.members))

--- a/server/corporation.py
+++ b/server/corporation.py
@@ -54,6 +54,7 @@ class Corporation:
 
     # Another corp will call this with their corp id to indicate that they want to be merged into our corp
     def merge_me(self, other_corp_id):
+        #print("Old corp size: {}".format(len(self.members)))
         self.sent_merge_invites = list([])  # Empties the sent merge invites list
         self.received_merge_invites = list([])  # Empties the received merge invites list
         # Incorporating their ore bank into our ore bank
@@ -62,6 +63,8 @@ class Corporation:
         # Setting the other corp's members corp to our corp
         for member in self.world.corporations[other_corp_id].members:
             member.corp = self
+            self.members.append(member)
 
         # Deletes the other corp to save memory
         self.world.corporations.pop(other_corp_id)
+        #print("New corp size: {}".format(len(self.members)))

--- a/server/corporation.py
+++ b/server/corporation.py
@@ -3,12 +3,15 @@ import gameObject, uuid
 
 class Corporation:
 
-    def __init__(self, initial_member):
+    def __init__(self, initial_member, _world):
         assert(initial_member.__class__.__name__ == 'Player')
 
         self.corp_id = str(uuid.uuid4())
+        self.world = _world
         self.members = []
         self.ore_quantity = 0
+        self.sent_merge_invites = []  # A list containing ids of corps that have been sent merge invites
+        self.received_merge_invites = []  # A list containing ids of corps that have sent use merge invites
 
         self.add_member(initial_member)
 
@@ -33,3 +36,10 @@ class Corporation:
             if player_id == member.obj_id:
                 return True
         return False
+
+    def receive_merge_invite(self, corp_id):
+        self.received_merge_invites.append(corp_id)
+
+    def send_merge_invite(self, corp_id):
+        self.sent_merge_invites.append(corp_id)
+        self.world.corporations[corp_id].receive_merge_invite(self.corp_id)

--- a/server/corporation.py
+++ b/server/corporation.py
@@ -27,3 +27,9 @@ class Corporation:
 
     def calculate_ore_loss_on_death(self):
         return int(self.ore_quantity / len(self.members))
+
+    def check_if_in_corp(self, player_id):
+        for member in self.members:
+            if player_id == member.obj_id:
+                return True
+        return False

--- a/server/corporation.py
+++ b/server/corporation.py
@@ -52,10 +52,16 @@ class Corporation:
                 corp_id_to_merge_with = received
                 self.world.corporations[corp_id_to_merge_with].merge_me(self.corp_id)
 
-    def merge_me(self, other_corp_id):  # Another corp will call this with their corp id to indicate that they want to be merged into our corp
+    # Another corp will call this with their corp id to indicate that they want to be merged into our corp
+    def merge_me(self, other_corp_id):
         self.sent_merge_invites = list([])  # Empties the sent merge invites list
         self.received_merge_invites = list([])  # Empties the received merge invites list
+        # Incorporating their ore bank into our ore bank
+        self.gain_ore(self.world.corporations[other_corp_id].ore_quantity)
 
-        self.gain_ore(self.world.corporations[other_corp_id].ore_quantity)  # Incorporates their ore bank into our ore bank
+        # Setting the other corp's members corp to our corp
         for member in self.world.corporations[other_corp_id].members:
-            member.corp = self  # Setting the other corp's members corp to our corp
+            member.corp = self
+
+        # Deletes the other corp to save memory
+        self.world.corporations.pop(other_corp_id)

--- a/server/player.py
+++ b/server/player.py
@@ -1,6 +1,7 @@
 import uuid, random
 from cell import Cell
 import gameObject
+import corporation
 
 
 class Player(gameObject.GameObject):
@@ -27,6 +28,7 @@ class Player(gameObject.GameObject):
         self.modifier_key = 'm'
         self.passable = False
         self.last_action_at_world_age = 0
+        self.corp = corporation.Corporation(self)
 
     def action(self, key_pressed):
         direction_keys = ['w', 'a', 's', 'd']

--- a/server/player.py
+++ b/server/player.py
@@ -152,7 +152,11 @@ class Player(gameObject.GameObject):
             if struct[0]:
                 other_player = _cell.get_game_object_by_obj_id(struct[1])
                 if other_player[0]:
-                    other_player[1].take_damage(self.attack_power)
+                    if self.corp.check_if_in_corp(struct[1]):
+                        return False # You cannot attack another player in your corp
+                    else:
+                        other_player[1].take_damage(self.attack_power)  # Attacking someone not in your corp
+                        return True
         return False
 
     def gain_ore(self, amount):

--- a/server/player.py
+++ b/server/player.py
@@ -20,6 +20,9 @@ class Player(gameObject.GameObject):
         self.attack_power = 10
         self.delta_ore = 0  # The ore lost/gained in the last tick
         self.inner_icon = '@'
+        self.neutral_icon = 'N'
+        self.enemy_icon = 'E'
+        self.ally_icon = 'A'
         self.icon = '!'
         self.row = self.cell.row
         self.col = self.cell.col

--- a/server/player.py
+++ b/server/player.py
@@ -31,7 +31,7 @@ class Player(gameObject.GameObject):
         self.modifier_key = 'm'
         self.passable = False
         self.last_action_at_world_age = 0
-        self.corp = corporation.Corporation(self)
+        self.corp = self.world.new_corporation(self)
 
     def action(self, key_pressed):
         direction_keys = ['w', 'a', 's', 'd']
@@ -107,7 +107,23 @@ class Player(gameObject.GameObject):
             return False
 
     def try_merge_corp(self, _cell):
-        return True
+        if _cell is not None:
+            struct = _cell.contains_object_type('Player')
+            if struct[0]:
+                other_player = _cell.get_game_object_by_obj_id(struct[1])
+                if other_player[0]:
+                    other_player_corp_id = other_player[1].get_corp_id()
+                    self.send_merge_invite(other_player_corp_id)
+        return False
+
+    def get_corp_id(self):
+        return self.corp.corp_id
+
+    def send_merge_invite(self, corp_id):
+        self.corp.send_merge_invite(corp_id)
+
+    def receive_merge_invite(self, corp_id):
+        self.corp.receive_merge_invite(corp_id)
 
     def try_looting(self, _cell):
         if _cell is not None:

--- a/server/player.py
+++ b/server/player.py
@@ -23,6 +23,7 @@ class Player(gameObject.GameObject):
         self.neutral_icon = 'N'
         self.enemy_icon = 'E'
         self.ally_icon = 'A'
+        self.corp_member_icon = 'M'
         self.icon = '!'
         self.row = self.cell.row
         self.col = self.cell.col
@@ -37,7 +38,10 @@ class Player(gameObject.GameObject):
         modifier_keys = {
             'k': "for attacking/killing",
             'm': "for moving",
-            'l': "for looting"
+            'l': "for looting",
+            'i': "for inviting corp to merge into current corp",
+            '-': "for setting a corp to a lower standing (A -> N -> E)",
+            '+': "for setting a corp to a higher standing (E -> N -> A)"
         }
         if key_pressed in direction_keys:
             self.dir_key = key_pressed
@@ -92,10 +96,18 @@ class Player(gameObject.GameObject):
                     return True
                 else:
                     return False
+            elif self.modifier_key == 'i':  # Player/Corp is trying to merge corps with another player
+                if self.try_merge_corp(affected_cell):
+                    return True
+                else:
+                    return False
             else:
                 return False
         else:
             return False
+
+    def try_merge_corp(self, _cell):
+        return True
 
     def try_looting(self, _cell):
         if _cell is not None:

--- a/server/server.py
+++ b/server/server.py
@@ -91,6 +91,8 @@ def action():
 
 @app.route('/sendState')
 def send_state(**keyword_parameters):
+    start_of_request = datetime.datetime.now()
+
     tick_server_if_needed()
     response = dict()
 
@@ -107,6 +109,9 @@ def send_state(**keyword_parameters):
     response['world'] = world.players[_id].world_state()
     response['id'] = _id
     response['vitals'] = world.players[_id].get_vitals()
+
+    request_time = datetime.datetime.now() - start_of_request
+    print("Time to answer sendState request: {}".format(request_time.microseconds / 1000))
     return home_cor(jsonify(**response))
 
 

--- a/server/world.py
+++ b/server/world.py
@@ -1,6 +1,7 @@
 import uuid, random, datetime
 from cell import Cell
 from player import Player
+from corporation import Corporation
 import helper_functions
 
 
@@ -14,6 +15,7 @@ class World:  # World is not really world, it's more Level
         self.last_tick = datetime.datetime.now()
         self.microseconds_per_tick = 350000
         self.players = dict()
+        self.corporations = dict()
 
         for row in range(self.rows):
             current_row = []
@@ -69,6 +71,11 @@ class World:  # World is not really world, it's more Level
         self.players[player_id] = new_player
 
         return player_id
+
+    def new_corporation(self, initial_player_object):
+        new_corp = Corporation(initial_player_object, self)
+        self.corporations[new_corp.corp_id] = new_corp
+        return new_corp
 
     def spawn_ore_deposits(self, num=1):
         assert(num <= self.rows * self.cols)

--- a/server/world.py
+++ b/server/world.py
@@ -10,8 +10,6 @@ class World:  # World is not really world, it's more Level
         self.rows = 31
         self.cols = 32
         self.world = []
-        self.rendered_world = []
-        self.world_age_when_world_was_rendered = 0
         self.world_age = 1
         self.last_tick = datetime.datetime.now()
         self.microseconds_per_tick = 350000
@@ -33,17 +31,26 @@ class World:  # World is not really world, it's more Level
         self.last_tick = datetime.datetime.now()
         self.world_age += 1
 
-    def cache_world(self):
-        rendered_world = []
-        for row in range(self.rows):
-            current_row = []
-            for col in range(self.cols):
-                rendered = self.world[row][col].render()
-                current_row.append(rendered)
-            rendered_world.append(current_row)
+    def render_world(self, **keyword_parameters):
+        if 'player_id' in keyword_parameters:
+            player_id = keyword_parameters['player_id']
+            rendered_world = []
+            for row in range(self.rows):
+                current_row = []
+                for col in range(self.cols):
+                    rendered = self.world[row][col].render(player_id=player_id)
+                    current_row.append(rendered)
+                rendered_world.append(current_row)
+        else:
+            rendered_world = []
+            for row in range(self.rows):
+                current_row = []
+                for col in range(self.cols):
+                    rendered = self.world[row][col].render()
+                    current_row.append(rendered)
+                rendered_world.append(current_row)
         assert(len(rendered_world) == 31, "Age: {} Len: {} Full: {}".format(self.world_age, len(rendered_world), rendered_world))
-        self.rendered_world = rendered_world
-        self.world_age_when_world_was_rendered = int(self.world_age)
+        return rendered_world
 
     def new_player(self):
         random_cell = self.get_random_cell()
@@ -92,28 +99,11 @@ class World:  # World is not really world, it's more Level
             random_cell.add_hospital()
 
     def get_world(self, **keyword_parameters):
-
-        if self.world_age_when_world_was_rendered != self.world_age:
-            assert(self.world_age_when_world_was_rendered != self.world_age)
-            self.cache_world()
-
-        assert(self.world_age_when_world_was_rendered == self.world_age)
-        assert(len(self.rendered_world) == 31, "Age: {} Len: {} Full: {}".format(self.world_age, len(self.rendered_world), self.rendered_world))
-        try:
-            assert(helper_functions.flatten_2d_list(self.rendered_world).count('@') == 0)
-        except AssertionError as e:
-            print("Had to render the world against due to pointer issues")
-            self.cache_world()
-
-        temp_world = list(self.rendered_world)
-        assert(len(temp_world) == 31)
-        assert(id(temp_world) != id(self.rendered_world))
         if 'player_id' in keyword_parameters:
             player_id = keyword_parameters['player_id']
-            _player = self.players[player_id]
-            temp_world[_player.row][_player.col] = _player.inner_icon  # Duplicate '@' problem happens here
-        assert(len(temp_world) == 31)
-        return temp_world
+            return self.render_world(player_id=player_id)
+        else:
+            return self.render_world()
 
     def valid_player_id(self, _id):
         if _id in self.players:


### PR DESCRIPTION
Fixes #29 

Patch Notes:

- Adds Corporations:
    - Invite other person's corp into yours by pressing `i` and choose them with the dir key
    - You cannot attack people in your corp
    - Each player starts in their own Corporation
    - Corporations now have the ore bank; Players do not have an ore bank anymore.
    - Due to the above, having multiple people in your corp mining will lead to a higher delta ore than if you were alone mining

- Removed world caching; world is now rendered in relation to the player every time get_world in World is called.
- Added datetime objects in game-server server.py to track how long a /sendState request takes to fulfill