### PR TITLE
[Alpha] Benevolent Bearded Dragon

### DIFF
--- a/node/child_game/cell.py
+++ b/node/child_game/cell.py
@@ -68,7 +68,6 @@ class Cell:
 
 		return False
 
-
 	def damage_first_player(self, attacking_corp: 'corporation.Corporation', damage):
 		struct = self.contains_object_type('Player')
 		if struct[0]:

--- a/node/child_game/cell.py
+++ b/node/child_game/cell.py
@@ -1,6 +1,6 @@
 import uuid
 from child_game import gameObject, world, corporation
-from typing import Tuple
+from typing import Tuple, List
 from child_game.exceptions import CellCoordinatesOutOfBoundsError
 from child_game import exceptions
 
@@ -20,7 +20,7 @@ class Cell:
 		except CellCoordinatesOutOfBoundsError:
 			raise CellCoordinatesOutOfBoundsError(self.row + row_offset, self.col + col_offset)
 
-	def next_to_ore_deposit(self):
+	def is_next_to_ore_deposit(self) -> bool:
 		directions = [[-1, 0], [-1, 1], [0, 1], [1, 1], [1, 0], [1, -1], [0, -1], [-1, -1]]
 		for tup in directions:
 			try:
@@ -35,6 +35,39 @@ class Cell:
 			except CellCoordinatesOutOfBoundsError:
 				pass
 		return False
+
+	def is_adjacent_to_sentry_turret(self, check_horizontally=True, check_vertically=True, check_diagonally=False,
+									 check_self=False):
+
+		directions_checked = []  # type: List[Tuple[int, int]]
+		if check_self:
+			directions_checked.append((0, 0))
+		if check_horizontally:
+			directions_checked.append((0, -1))
+			directions_checked.append((0, 1))
+		if check_vertically:
+			directions_checked.append((-1, 0))
+			directions_checked.append((1, 0))
+		if check_diagonally:
+			directions_checked.append((-1, -1))
+			directions_checked.append((-1, 1))
+			directions_checked.append((1, 1))
+			directions_checked.append((1, -1))
+
+		for offset_tuple in directions_checked:
+			try:
+				_cell = self.get_cell_by_offset(offset_tuple[0], offset_tuple[1])
+				try:
+					turret_id = _cell.get_object_id_of_first_game_object_found('SentryTurret')
+					return True
+				except exceptions.NoGameObjectOfThatClassFoundException:
+					pass
+
+			except CellCoordinatesOutOfBoundsError:
+				pass
+
+		return False
+
 
 	def damage_first_player(self, attacking_corp: 'corporation.Corporation', damage):
 		struct = self.contains_object_type('Player')

--- a/node/child_game/player.py
+++ b/node/child_game/player.py
@@ -452,7 +452,7 @@ class Player(gameObject.GameObject):
 
 	def construct_ore_generator(self, _cell: 'Cell') -> None:
 		if _cell.can_enter(player_obj=self):
-			if _cell.next_to_ore_deposit():
+			if _cell.is_next_to_ore_deposit():
 				ore_cost = gameObject.OreGenerator.construction_cost
 				if self.corp.amount_of_ore() >= ore_cost:
 					_cell.add_corp_owned_building(self.corp, 'OreGenerator')

--- a/node/child_game/player.py
+++ b/node/child_game/player.py
@@ -396,7 +396,10 @@ class Player(gameObject.GameObject):
 		self.health = min(self.health_cap, self.health + amount)
 
 	def construct_sentry_turret(self, _cell: 'Cell') -> None:
-		if _cell.can_enter(player_obj=self):
+		if _cell.can_enter(player_obj=self) and _cell.is_adjacent_to_sentry_turret(check_diagonally=True,
+																				   check_horizontally=True,
+																				   check_vertically=True,
+																				   check_self=True) is False:
 			ore_cost = gameObject.SentryTurret.construction_cost
 			if self.corp.amount_of_ore() >= ore_cost:
 				_cell.add_corp_owned_building(self.corp, 'SentryTurret')

--- a/patchnotes/1.4.8_Benevolent_Bearded_Dragon_Alpha.md
+++ b/patchnotes/1.4.8_Benevolent_Bearded_Dragon_Alpha.md
@@ -1,7 +1,7 @@
 And/Ore v1.4.8
 ============
 
-Benevolent Bearded Dragon Alpha Release
+[Alpha] Benevolent Bearded Dragon Release
 =====================
 
 ![Drawing of a Benevolent Bearded Dragon](../Art_Assets/Update_Pictures/Benevolent_Bearded_Dragon.png)

--- a/patchnotes/1.4.8_Benevolent_Bearded_Dragon_Alpha.md
+++ b/patchnotes/1.4.8_Benevolent_Bearded_Dragon_Alpha.md
@@ -1,7 +1,7 @@
-And/Ore v1.5
+And/Ore v1.4.8
 ============
 
-Benevolent Bearded Dragon Release
+Benevolent Bearded Dragon Alpha Release
 =====================
 
 ![Drawing of a Benevolent Bearded Dragon](../Art_Assets/Update_Pictures/Benevolent_Bearded_Dragon.png)


### PR DESCRIPTION
* Added patchnotes for v1.4.8 (the Alpha of Benevolent Bearded Dragon)
* Sentry Turrets can no longer be constructed while directly (even diagonally) adjacent to another Sentry Turret